### PR TITLE
Issue2 save well positions

### DIFF
--- a/flyMultiPlateScript.m
+++ b/flyMultiPlateScript.m
@@ -214,8 +214,6 @@ if fileMode == 1
     cd(pathName);
     if not(exist(timestampFileName,'file') == 2)
         [timestampFileName,timestampPathName] = uigetfile({'*.csv'},strcat('Select the timestamp file associated with: ',fileName));
-        %Changing to this directory assuming we'll find the wellposes file there too
-        cd(timestampPathName);
     else
         timestampPathName = pathName;
     end
@@ -229,13 +227,12 @@ if fileMode == 1
         wellposesPathName = timestampPathName;
 
         %Check the existence of the associated wellposes file
-        if not(exist(wellposesFileName,'file') == 2)
+        if not(exist(fullfile(wellposesPathName,wellposesFileName),'file') == 2)
             [wellposesFileName,wellposesPathName] = uigetfile({'*.mat'},strcat('Select the well positions file associated with: ',fileName));
         end
 
-        %Load the wellposes mat file (two temp variables we'll use later)
-        cd(wellposesPathName);
-        load(wellposesFileName);
+        %Load the wellposes mat file (temp variables we'll use later)
+        load(fullfile(wellposesPathName,wellposesFileName))
         
     end
 

--- a/flyMultiPlateScript.m
+++ b/flyMultiPlateScript.m
@@ -231,7 +231,7 @@ if fileMode == 1
 
         %Check the existence of the associated wellposes file
         if not(exist(tmpwellposesFileName,'file') == 2)
-            [tmpwellposesFileName,wellposesPathName] = uigetfile({'*.csv'},strcat('Select the timestamp file associated with: ',fileName));
+            [tmpwellposesFileName,wellposesPathName] = uigetfile({'*.mat'},strcat('Select the well positions file associated with: ',fileName));
             %Remove the .mat for the load function (which doesn't take the filename with '.mat')
             wellposesFileName = strrep(tmpwellposesFileName,'.mat','');
         else

--- a/flyMultiPlateScript.m
+++ b/flyMultiPlateScript.m
@@ -225,17 +225,12 @@ if fileMode == 1
         %% Find the well positions file
 
         % Assume the well positions file is in the same place as the timestamps file
-        wellposesFileName = strrep(timestampFileName,'-wellposes');
-        tmpwellposesFileName = strcat(wellposesFileName,'.mat');
+        wellposesFileName = strrep(timestampFileName,'-wellposes.mat');
         wellposesPathName = timestampPathName;
 
         %Check the existence of the associated wellposes file
-        if not(exist(tmpwellposesFileName,'file') == 2)
-            [tmpwellposesFileName,wellposesPathName] = uigetfile({'*.mat'},strcat('Select the well positions file associated with: ',fileName));
-            %Remove the .mat for the load function (which doesn't take the filename with '.mat')
-            wellposesFileName = strrep(tmpwellposesFileName,'.mat','');
-        else
-            wellposesPathName = pathName;
+        if not(exist(wellposesFileName,'file') == 2)
+            [wellposesFileName,wellposesPathName] = uigetfile({'*.mat'},strcat('Select the well positions file associated with: ',fileName));
         end
 
         %Load the wellposes mat file (two temp variables we'll use later)

--- a/flyMultiPlateScript.m
+++ b/flyMultiPlateScript.m
@@ -246,6 +246,8 @@ for camIdx = 1:nCamsToUse
     if fileMode == 0 && makeBackupVideo == 1
         fileNameBackupVid{camIdx}    = strcat(tmpFileName,vidExtension);
         fileNameBackupTimes{camIdx}  = strcat(tmpFileName,'-timestamps.csv');
+        % The following will end up with a .mat extension appended
+        fileNameBackupWells{camIdx}  = strcat(tmpFileName,'-wellposes');
     end
 
     %% get file ready for writing
@@ -433,6 +435,17 @@ for camIdx=1:nCamsToUse
     end
 
 end
+
+%Save the well position data to .mat files for each camera
+if fileMode == 0 && makeBackupVideo == 1
+    for camIdx=1:nCamsToUse
+        %Create temporary variables to save
+        wellCoords  = wellCoordinates{camIdx};
+        wellSpacing = wellSpacingPix{camIdx};
+        save(fileNameBackupWells{camIdx},'wellCoords','wellSpacing');
+    end
+end
+
 
 %Print column headers for memory usage output
 msg = ['Secs',char(9),'Mb Added Since Start'];


### PR DESCRIPTION
Resolves issue #2

It would be good to have a couple pairs of eyes look this over.

These changes basically save the well position related data in a .mat file during a live cam run and load them back in during a run using a saved video from a previous run.  The user has the option of re-picking the well positions.